### PR TITLE
64 wqi graph not appearing in wqi tab

### DIFF
--- a/functions/wqi_site_plot.R
+++ b/functions/wqi_site_plot.R
@@ -48,12 +48,13 @@ monthly_wqi_plot<-function(monthly_wqi_by_parameter,monthly_wqi,input){
   monthly_wqi_ggplot<-monthly_wqi_by_parameter %>%
     filter(site==input$main_site&WaterYear==input$wqi_year) %>%
     left_join(monthly_wqi %>% rename(`Summary Score`=WQI)) %>%
-  select(site, WaterYear, Month,`Summary Score`, Bacteria=FC, Oxygen, pH, Temperature=Temp, Sediment, Nutrient) %>%
+  #select(site, WaterYear, Month,`Summary Score`, Bacteria=FC, Oxygen, pH, Temperature=Temp, Sediment, Nutrient) %>%
   tidyr::pivot_longer(cols=-c(site:Month),names_to = 'Parameter',values_to = 'WQI') %>%
   select(site,WaterYear,Month,Parameter,WQI) %>%
   mutate(Parameter=factor(Parameter,levels=c('Summary Score','Temperature','Oxygen','pH','Bacteria',
                                              'Sediment','Nutrient')),
          Month=factor(Month,c(10:12,1:9),labels=month.abb[c(10:12,1:9)])) %>%
+    filter(!is.na(Parameter)) %>%
   #ggplot()+
   ggplot(aes(x=Month,y=WQI,col=Parameter))+
   geom_line(alpha=.75,aes(group=Parameter))+

--- a/functions/wqi_site_plot.R
+++ b/functions/wqi_site_plot.R
@@ -4,15 +4,15 @@
 
 
 wqi_annual_plot<-function(annual_wqi,input){
-annual_wqi %>%
-  filter(site==input$main_site) %>%
-  ggplot(aes(x=WaterYear,y=WQI))+
-  geom_point(data=~filter(.x,WaterYear==input$wqi_year),col='red',size=4)+
-  geom_point()+
-  geom_smooth(data=~filter(.x,WaterYear>=input$wqi_trend_years[1]&WaterYear<=input$wqi_trend_years[2]),se=F)+
-  theme_bw()+
-  xlab('Water year')+
-  scale_y_continuous('Water Quality Index',limits = c(0,100))
+  annual_wqi %>%
+    filter(site==input$main_site) %>%
+    ggplot(aes(x=WaterYear,y=WQI))+
+    geom_point(data=~filter(.x,WaterYear==input$wqi_year),col='red',size=4)+
+    geom_point()+
+    geom_smooth(data=~filter(.x,WaterYear>=input$wqi_trend_years[1]&WaterYear<=input$wqi_trend_years[2]),se=F)+
+    theme_bw()+
+    xlab('Water year')+
+    scale_y_continuous('Water Quality Index',limits = c(0,100))
 }
 
 wqi_trend_text<-function(annual_wqi,input){
@@ -40,30 +40,30 @@ wqi_trend_text<-function(annual_wqi,input){
   HTML(paste0('<u>Mann-Kendall Trend Test:</u>','<br/>',
               'Between water years <b>',wqi_trend_out$StartYear,'</b> and <b>',wqi_trend_out$EndYear,'</b>',
               ', there is ',ifelse(is.na(wqi_trend_out$p),'inadequate data to evalute a trend',
-                                            paste0('<b>',wqi_trend_out$sigStatement,"</b>",' in <b>','WQI','</b><br/>',
-              wqi_trend_out$slopeStatement))))
-  }
+                                   paste0('<b>',wqi_trend_out$sigStatement,"</b>",' in <b>','WQI','</b><br/>',
+                                          wqi_trend_out$slopeStatement))))
+}
 
 monthly_wqi_plot<-function(monthly_wqi_by_parameter,monthly_wqi,input){
   monthly_wqi_ggplot<-monthly_wqi_by_parameter %>%
     filter(site==input$main_site&WaterYear==input$wqi_year) %>%
     left_join(monthly_wqi %>% rename(`Summary Score`=WQI)) %>%
-  #select(site, WaterYear, Month,`Summary Score`, Bacteria=FC, Oxygen, pH, Temperature=Temp, Sediment, Nutrient) %>%
-  tidyr::pivot_longer(cols=-c(site:Month),names_to = 'Parameter',values_to = 'WQI') %>%
-  select(site,WaterYear,Month,Parameter,WQI) %>%
-  mutate(Parameter=factor(Parameter,levels=c('Summary Score','Temperature','Oxygen','pH','Bacteria',
-                                             'Sediment','Nutrient')),
-         Month=factor(Month,c(10:12,1:9),labels=month.abb[c(10:12,1:9)])) %>%
+    #select(site, WaterYear, Month,`Summary Score`, Bacteria=FC, Oxygen, pH, Temperature=Temp, Sediment, Nutrient) %>%
+    tidyr::pivot_longer(cols=-c(site:Month),names_to = 'Parameter',values_to = 'WQI') %>%
+    select(site,WaterYear,Month,Parameter,WQI) %>%
+    mutate(Parameter=factor(Parameter,levels=c('Summary Score','Temperature','Oxygen','pH','Bacteria',
+                                               'Sediment','Nutrient')),
+           Month=factor(Month,c(10:12,1:9),labels=month.abb[c(10:12,1:9)])) %>%
     filter(!is.na(Parameter)) %>%
-  #ggplot()+
-  ggplot(aes(x=Month,y=WQI,col=Parameter))+
-  geom_line(alpha=.75,aes(group=Parameter))+
-  geom_point(alpha=.75)+
-  theme_bw()+
-  xlab('Month')+
-  scale_y_continuous('Water Quality Index',limits = c(0,100))+
-  scale_color_manual(values=c('Summary Score'='black','Temperature'='red','Oxygen'='blue','pH'='yellow',
-                              'Bacteria'='brown','Sediment','rosybrown','Nutrient'='green'))
-ggplotly(monthly_wqi_ggplot) %>%
-  layout(legend=list(title=list(text='Parameter')))
+    #ggplot()+
+    ggplot(aes(x=Month,y=WQI,col=Parameter))+
+    geom_line(alpha=.75,aes(group=Parameter))+
+    geom_point(alpha=.75)+
+    theme_bw()+
+    xlab('Month')+
+    scale_y_continuous('Water Quality Index',limits = c(0,100))+
+    scale_color_manual(values=c('Summary Score'='black','Temperature'='red','Oxygen'='blue','pH'='yellow',
+                                'Bacteria'='brown','Sediment','rosybrown','Nutrient'='green'))
+  ggplotly(monthly_wqi_ggplot) %>%
+    layout(legend=list(title=list(text='Parameter')))
 }

--- a/server.R
+++ b/server.R
@@ -99,8 +99,8 @@ server<-function(input,output,session){
   observeEvent(input$trend_summary_map_marker_click, {
     p <- input$trend_summary_map_marker_click
     if(!is.null(p$id)){
-    updateSelectInput(session, "trend_summary_site", 
-                      selected =p$id)
+      updateSelectInput(session, "trend_summary_site", 
+                        selected =p$id)
     }
   })
   
@@ -159,17 +159,31 @@ server<-function(input,output,session){
     trend_text(dataSubset(),input)
   })
   
-
+  
   
   #Individual WQI Plot
-
+  
   output$wqi_annual<-renderPlotly({
     ggplotly(wqi_annual_plot(annual_wqi,input),
              source='wqi_year_select') %>% event_register("plotly_click")
   })
   output$wqi_trend_text<-renderUI({
     wqi_trend_text(annual_wqi,input)
-})
+  })
+  
+  wqi_data_present <- reactive({
+    data_missing_test <- monthly_wqi_by_parameter %>%
+      filter(WaterYear == input$wqi_year)
+    input$wqi_year %in% data_missing_test$WaterYear & input$main_site %in% data_missing_test$site == TRUE
+  })
+  
+  output$data_missing_message <- renderUI({
+    if (wqi_data_present()) {
+      NULL
+    } else {
+      h4("There is not enough data to display the monthly WQI. Please adjust your selection to display the data.")
+    }
+  })
   
   output$wqi_monthly<-renderPlotly({
     monthly_wqi_plot(monthly_wqi_by_parameter,monthly_wqi,input)

--- a/ui.R
+++ b/ui.R
@@ -240,9 +240,8 @@ ui<-
                    )
                    ,
                    mainPanel(width=9,
-                             p("TODO: TEST1"),
+                             uiOutput("data_missing_message"),
                              fluidRow(plotlyOutput('wqi_monthly')),
-                             p("TODO: test"),
                              fluidRow(plotlyOutput('wqi_annual')),
                              htmlOutput('wqi_trend_text')
                              

--- a/ui.R
+++ b/ui.R
@@ -240,7 +240,9 @@ ui<-
                    )
                    ,
                    mainPanel(width=9,
+                             p("TODO: TEST1"),
                              fluidRow(plotlyOutput('wqi_monthly')),
+                             p("TODO: test"),
                              fluidRow(plotlyOutput('wqi_annual')),
                              htmlOutput('wqi_trend_text')
                              


### PR DESCRIPTION
This was a three-fold problem. 
1. There was a select() function in the wqi_site_plot.R script (line 51) that was selecting non-existent parameters, which prevented the graph from appearing under any circumstances. I commented that out and got a rendered graph occasionally. 

2. Second problem was that an 'NA' parameter was being created in a mutate command by accident, and was being plotted on the wqi monthly plot. I added a line to drop NAs in the Parameter column.

3. Last problem was that the user input needed to be present in the subsequently filtered graph. If the user selects 2019, Beaver Creek, all that data needed to be in the data frame and it often isn't. I added a small print UI element and an associated test in the server to check if the data was present when filtered for user input. If it is, the graph appears. If it's not, a message appears asking the user to adjust their input. 